### PR TITLE
US-03: implement dashboard trip overview from backend

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,35 +2,71 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
+import { Trip } from "@/types/trip";
 
 export default function DashboardPage() {
   const router = useRouter();
   const { clear: clearToken } = useLocalStorage("token", "");
   const { clear: clearUserId } = useLocalStorage("userId", "");
+  const apiService = useApi();
+  const { value: token } = useLocalStorage<string>("token", "");
+  const { value: currentUserId } = useLocalStorage<string>("userId", "");
 
   const handleLogout = () => {
     clearToken();
     clearUserId();
     router.push("/login");
   };
-        // Mock data for demonstration purposes
-  const myTrips = [
-    { id: 1, name: "Summer Vacation", members: "Erica, Michael, Andrew, Luana" },
-    { id: 2, name: "Winter Vacation", members: "Sarah, Mike, Lana" },
-    { id: 3, name: "Weekend Trip", members: "Kevin, Michaela" },
-    { id: 4, name: "Solo Getaway", members: "Just Me" },
-  ];
 
-  const sharedTrips = [
-    { id: 5, name: "Friends Trip", members: "Liam, Emma" },
-    { id: 6, name: "Romantic", members: "Lucas" },
-    { id: 7, name: "Theaters!", members: "Adrian, Nora" },
-    { id: 8, name: "DaVinci Time", members: "Theo" },
-    { id: 9, name: "Beach pls", members: "Mila, Hannah" },
-    { id: 10, name: "Culture or sth.", members: "Tobias, Lea" },
-  ];
+  const [trips, setTrips] = useState<Trip[]>([]);
+  const [loadingTrips, setLoadingTrips] = useState(true);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+      if (!token) {
+      router.push("/login");
+      return;
+    }
+
+    const fetchTrips = async () => {
+      try {
+        setLoadingTrips(true);
+        setFeedback(null);
+        const response = await apiService.get<Trip[]>("/trips");
+        setTrips(response ?? []);
+      } catch (error) {
+        const err = error as Error & { status?: number };
+        if (err.status === 404) {
+          setFeedback("Trip overview endpoint is not available yet on the backend.");
+        } else {
+          setFeedback("Failed to load trips from backend. Please try again.");
+        }
+      } finally {
+        setLoadingTrips(false);
+      }
+    };
+
+    fetchTrips();
+  }, [token, apiService, router]);
+
+  const myTrips = useMemo(
+    () => trips.filter((trip) => !!trip.hostId && !!currentUserId && trip.hostId === currentUserId),
+    [trips, currentUserId],
+  );
+
+  const sharedTrips = useMemo(
+    () => trips.filter((trip) => !trip.hostId || !currentUserId || trip.hostId !== currentUserId),
+    [trips, currentUserId],
+  );
+
+  if (!token) {
+    return null;
+  }
+
   return (
     <div className="grid grid-cols-[270px_1fr] h-screen overflow-hidden bg-[#f7f7f7] text-[#111]">
       {/* Sidebar */}
@@ -78,18 +114,30 @@ export default function DashboardPage() {
             <button className="border-none rounded-[10px] px-5 py-3 text-[15px] font-semibold cursor-pointer bg-[#2684ff] text-white" type="button">
               Join Trip
             </button>
-            <button className="border-none rounded-[10px] px-5 py-3 text-[15px] font-semibold cursor-pointer bg-[#2684ff] text-white" type="button">
+            <button
+              className="border-none rounded-[10px] px-5 py-3 text-[15px] font-semibold cursor-pointer bg-[#2684ff] text-white"
+              type="button"
+              onClick={() => router.push("/trips/create")}
+            >
               Create Trip
             </button>
           </div>
         </header>
 
-        {myTrips.length === 0 && sharedTrips.length === 0 ? (
+        {feedback && (
+          <p className="mb-5 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            {feedback}
+          </p>
+        )}
+
+        {loadingTrips && <p className="text-sm text-[#666]">Loading trips from backend...</p>}
+
+        {!loadingTrips && myTrips.length === 0 && sharedTrips.length === 0 ? (
           <section className="flex flex-col items-center justify-center h-full">
             <h1 className="text-5xl font-bold mb-2">Need a Vacation?</h1>
             <p className="text-lg text-[#666]">Create or join one with TripSync</p>
           </section>
-        ) : (
+        ) : !loadingTrips ? (
           <>
             <section id="my-trips" className="mb-14">
               <h1 className="m-0 mb-2 text-[56px] font-bold leading-tight">My Trips</h1>
@@ -97,10 +145,13 @@ export default function DashboardPage() {
 
               <div className="grid grid-cols-4 gap-7">
                 {myTrips.map((trip) => (
-                  <Link key={trip.id} href={`/trips/${trip.id}`} className="block no-underline text-inherit cursor-pointer hover:scale-[1.02] transition-transform">
+                  <Link key={trip.id ?? `my-${trip.roomCode ?? trip.name}`} href={`/trips/${trip.roomCode}`} className="block no-underline text-inherit cursor-pointer hover:scale-[1.02] transition-transform">
                     <div className="w-full aspect-square rounded-2xl bg-gradient-to-br from-[#c9d8f0] to-[#8fb0d8] mb-3.5" />
-                    <h3 className="m-0 mb-1.5 text-[22px] font-semibold">{trip.name}</h3>
-                    <p className="m-0 text-sm text-[#666]">{trip.members}</p>
+                    <h3 className="m-0 mb-1.5 text-[22px] font-semibold">{trip.name ?? "Untitled Trip"}</h3>
+                    <p className="m-0 text-sm text-[#666]">Status: {(trip.status ?? "N/A").toLowerCase()}</p>
+                    <p className="m-0 text-sm text-[#666]">
+                      Created: {trip.creationDate ? new Date(trip.creationDate).toLocaleDateString() : "N/A"}
+                    </p>
                   </Link>
                 ))}
               </div>
@@ -112,16 +163,19 @@ export default function DashboardPage() {
 
               <div className="grid grid-cols-6 gap-6">
                 {sharedTrips.map((trip) => (
-                  <Link key={trip.id} href={`/trips/${trip.id}`} className="block no-underline text-inherit cursor-pointer hover:scale-[1.02] transition-transform">
+                  <Link key={trip.id ?? `shared-${trip.roomCode ?? trip.name}`} href={`/trips/${trip.roomCode}`} className="block no-underline text-inherit cursor-pointer hover:scale-[1.02] transition-transform">
                     <div className="w-full aspect-square rounded-2xl bg-gradient-to-br from-[#d7d7d7] to-[#bdbdbd] mb-3" />
-                    <h3 className="m-0 mb-1.5 text-lg font-semibold">{trip.name}</h3>
-                    <p className="m-0 text-sm text-[#666]">{trip.members}</p>
+                    <h3 className="m-0 mb-1.5 text-lg font-semibold">{trip.name ?? "Untitled Trip"}</h3>
+                    <p className="m-0 text-sm text-[#666]">Status: {(trip.status ?? "N/A").toLowerCase()}</p>
+                    <p className="m-0 text-sm text-[#666]">
+                      Created: {trip.creationDate ? new Date(trip.creationDate).toLocaleDateString() : "N/A"}
+                    </p>
                   </Link>
                 ))}
               </div>
             </section>
           </>
-        )}
+        ) : null}
       </main>
     </div>
   );

--- a/app/trips/create/page.tsx
+++ b/app/trips/create/page.tsx
@@ -57,7 +57,7 @@ export default function CreateTrip() {
         if (err.status === 409) {
           setFeedback({ type: "error", text: "Trip name already exists. Please choose another name." });
         } else if (err.status === 400) {
-          setFeedback({ type: "error", text: "Invalid trip name. Please provide a valid name." });
+          setFeedback({ type: "error", text: err.message || "Invalid request. Please check your trip data." });
         } else {
           setFeedback({ type: "error", text: err.message || "Failed to create trip. Please try again." });
         }


### PR DESCRIPTION
Implements US-03 trip overview on the dashboard using backend data instead of mock data.
Trips are fetched from [/trips], split into My Trips and Shared Trips, and each card now shows name, status, and creation date.
Adds empty state, loading/error handling, and clickable trip cards that navigate to trip details.
Keeps existing logout behavior intact.