### PR TITLE
Feature/us11 fe comment on activity

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -1,5 +1,6 @@
 import { getApiDomain } from "@/utils/domain";
 import { ApplicationError } from "@/types/error";
+import { ActivitySearchResult } from "@/types/activity";
 
 export class ApiService {
   private baseURL: string;
@@ -154,6 +155,19 @@ export class ApiService {
    */
   public async voteOnActivity(activityId: number, voteType: "UP" | "DOWN") {
     return this.put(`/activities/${activityId}/vote`, { voteType });
+  }
+
+  /**
+   * Update a comment on an activity.
+   * @param activityId - The ID of the activity to comment on.
+   * @param comment - The comment text to save.
+   * @returns Updated activity payload.
+   */
+  public async updateActivityComment(
+    activityId: number,
+    comment: string | null,
+  ): Promise<ActivitySearchResult> {
+    return this.put<ActivitySearchResult>(`/activities/${activityId}/comment`, { comment });
   }
 
   /**

--- a/app/types/activity.ts
+++ b/app/types/activity.ts
@@ -7,6 +7,7 @@ export interface ActivitySearchResult {
   photoUrl: string | null;
   latitude: number | null;
   longitude: number | null;
+  comment?: string | null;
   upvotes?: number;
   downvotes?: number;
   score?: number;


### PR DESCRIPTION
ID: US-11
Story: As a user in a trip room, I want to comment on the activity.
Acceptance Criteria:
• By clicking on the activity, the user can leave a comment to explain or express what he’s thinking about the activity.
• This comment is shown next to the activity.
• The comment has a max. Number of characters, so that it doesn’t disturb the layout.

Extend the client type in activity.ts by adding the comment field so the trip-room render can show it without type errors.
Added comment API method in apiService.ts to call new backend comment endpoint and return the updated activity payload.

Addresses parts of Issue #11. Fixes #11 
