### PR TITLE
Implement activity deletion frontend flow US12

### DIFF
--- a/Manual_Tests/US12_MANUAL_TESTS.md
+++ b/Manual_Tests/US12_MANUAL_TESTS.md
@@ -1,0 +1,84 @@
+# US-12 Manual Test Cases
+
+## Scope
+Activity delete flow in trip room:
+- Owner can see delete control and delete successfully
+- Non-owner cannot delete
+- Deletion is blocked when activity has upvotes
+- Confirmation dialog behavior
+- UI and persistence consistency after actions
+
+## Preconditions
+- Backend server is running.
+- Frontend app is running.
+- User A and User B exist and can log in.
+- A trip room exists with at least one destination.
+- At least one activity exists that was created by User A.
+
+## TC1 - Delete Button Visibility (Owner)
+1. Log in as User A (creator of the activity).
+2. Open the trip room and navigate to the destination containing the activity.
+3. Locate the activity card.
+
+Expected:
+- A delete button (trash icon) is visible on the activity card.
+
+## TC2 - Delete Button Visibility (Non-Owner)
+1. Log out and log in as User B (not creator).
+2. Open the same trip room and destination.
+3. Locate the same activity card.
+
+Expected:
+- No delete button is shown for that activity.
+- User B cannot trigger deletion from the UI.
+
+## TC3 - Confirmation Dialog Opens and Cancels
+1. Log in as User A.
+2. Click the delete button on an own activity.
+
+Expected:
+- A confirmation dialog opens.
+- Dialog text indicates that deletion cannot be undone.
+
+3. Click Cancel.
+
+Expected:
+- Dialog closes.
+- Activity remains visible in the list.
+
+## TC4 - Successful Deletion After Confirmation
+1. Log in as User A.
+2. Click delete on an own activity.
+3. In the confirmation dialog, click Delete.
+
+Expected:
+- Activity is removed from the destination activity list immediately.
+- A page refresh does not restore the deleted activity.
+
+## TC5 - Deletion Blocked for Activity With Upvotes
+1. Ensure an activity created by User A has at least 1 upvote.
+2. As User A, click delete on that activity and confirm.
+
+Expected:
+- Activity is not deleted.
+- Error feedback is shown: deletion is not allowed because the activity has received votes.
+- Activity remains visible after refresh.
+
+## TC6 - Deletion Blocked for Non-Owner (Server-Side Authorization)
+1. Identify an activity created by User A.
+2. As User B, attempt to call the delete endpoint for that activity (e.g. via API client with User B token).
+
+Expected:
+- Backend returns HTTP 403 Forbidden.
+- Activity is unchanged and still visible in UI after refresh.
+
+## TC7 - Endpoint Contract for Successful Delete
+1. As activity owner, trigger deletion (from UI or API client).
+
+Expected:
+- Backend responds with HTTP 204 No Content.
+- No response body is required.
+
+## Notes
+- If test data is reused, recreate deleted activities before rerunning dependent test cases.
+- For TC5 and TC6, verify both immediate UI state and state after browser refresh.

--- a/app/trips/[id]/page.tsx
+++ b/app/trips/[id]/page.tsx
@@ -111,6 +111,41 @@ export default function TripRoom() {
   const [activityResults, setActivityResults] = useState<ActivitySearchResult[] | null>(null);
   const [activityLoading, setActivityLoading] = useState(false);
   const [activityFeedback, setActivityFeedback] = useState<{ type: "error" | "success"; text: string } | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [activityToDelete, setActivityToDelete] = useState<{ activity: ActivitySearchResult; destinationId: number } | null>(null);
+
+  const openDeleteConfirm = useCallback((activity: ActivitySearchResult, destinationId: number) => {
+    setActivityToDelete({ activity, destinationId });
+    setDeleteConfirmOpen(true);
+  }, []);
+
+  const closeDeleteConfirm = useCallback(() => {
+    setDeleteConfirmOpen(false);
+    setActivityToDelete(null);
+  }, []);
+
+  const confirmDeleteActivity = useCallback(async () => {
+    if (!activityToDelete || !trip) return;
+    const { activity, destinationId } = activityToDelete;
+    try {
+      await apiService.delete(`/trips/${trip.id}/destinations/${destinationId}/activities/${activity.id}`);
+      setActivitiesByDestination((current) => ({
+        ...current,
+        [destinationId]: (current[destinationId] ?? []).filter((a) => a.id !== activity.id),
+      }));
+      closeDeleteConfirm();
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      if (status === 403) {
+        setFeedback({ type: "error", text: "Only the creator can delete this activity." });
+      } else if (status === 400) {
+        setFeedback({ type: "error", text: "Cannot delete an activity that has received votes." });
+      } else {
+        setFeedback({ type: "error", text: "Failed to delete activity. Please try again." });
+      }
+      closeDeleteConfirm();
+    }
+  }, [activityToDelete, apiService, closeDeleteConfirm, trip]);
 
   const handleLogout = useCallback(() => {
     clearToken();
@@ -679,11 +714,34 @@ export default function TripRoom() {
                       ) : (
                         [...items]
                           .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-                          .map((activity) => (
-                          <article
-                            key={activity.id ?? activity.placeId ?? `${activity.name}-${activity.address}`}
-                            className="flex gap-4 rounded-xl border border-gray-200 bg-white p-4"
-                          >
+                          .map((activity) => {
+                            const isOwner =
+                              activity.createdBy !== null
+                              && activity.createdBy !== undefined
+                              && currentUserId
+                              && Number(currentUserId) === activity.createdBy;
+
+                            return (
+                              <article
+                                key={activity.id ?? activity.placeId ?? `${activity.name}-${activity.address}`}
+                                className="relative flex gap-4 rounded-xl border border-gray-200 bg-white p-4"
+                              >
+                            {isOwner && (
+                              <button
+                                type="button"
+                                aria-label="Delete activity"
+                                title="Delete activity"
+                                className="absolute top-2 right-2 rounded-md p-1 text-gray-500 transition hover:bg-red-50 hover:text-red-600"
+                                onClick={() => openDeleteConfirm(activity, destination.id)}
+                              >
+                                <svg viewBox="0 0 24 24" fill="none" className="h-4 w-4" aria-hidden="true">
+                                  <path d="M4 7h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                                  <path d="M9 4h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                                  <path d="M7 7l1 12h8l1-12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                  <path d="M10 11v5M14 11v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                                </svg>
+                              </button>
+                            )}
                             {activity.photoUrl ? (
                               <img
                                 src={activity.photoUrl}
@@ -707,8 +765,9 @@ export default function TripRoom() {
                                 <VoteControls activity={activity} onVoteUpdate={handleVoteUpdate} onError={handleVoteError} />
                               </div>
                             </div>
-                          </article>
-                        ))
+                              </article>
+                            );
+                          })
                       )}
                     </div>
 
@@ -852,6 +911,34 @@ export default function TripRoom() {
                     className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
                   >
                     Close
+                  </button>
+                </div>
+              </DialogPanel>
+            </div>
+          </Dialog>
+
+          <Dialog open={deleteConfirmOpen} onClose={closeDeleteConfirm} className="relative z-50">
+            <DialogBackdrop className="fixed inset-0 bg-black/30" />
+            <div className="fixed inset-0 flex items-center justify-center p-4">
+              <DialogPanel className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl ring-1 ring-gray-200">
+                <DialogTitle className="text-lg font-semibold text-gray-900">Delete activity</DialogTitle>
+                <p className="mt-2 text-sm text-gray-600">
+                  Are you sure you want to delete this activity? This action cannot be undone.
+                </p>
+                <div className="mt-5 flex justify-end gap-3">
+                  <button
+                    type="button"
+                    onClick={closeDeleteConfirm}
+                    className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmDeleteActivity}
+                    className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700"
+                  >
+                    Delete
                   </button>
                 </div>
               </DialogPanel>

--- a/app/types/activity.ts
+++ b/app/types/activity.ts
@@ -7,6 +7,7 @@ export interface ActivitySearchResult {
   photoUrl: string | null;
   latitude: number | null;
   longitude: number | null;
+  createdBy?: number | null;
   upvotes?: number;
   downvotes?: number;
   score?: number;


### PR DESCRIPTION
[FE] Add delete button for activities sopra-fs26-group-38-client#90

[FE] Add confirmation dialog before deleting an activity sopra-fs26-group-38-client#96

[FE] Call backend delete request after confirmation sopra-fs26-group-38-client#91

[FE] Show error message when activity deletion is not allowed sopra-fs26-group-38-client#110

[FE] Remove deleted activity from the UI after success sopra-fs26-group-38-client#105

[TEST] Write frontend/manual tests for activity delete flow sopra-fs26-group-38-client#122