### PR TITLE
add destination deletion and adjusted edit button in trip cards

### DIFF
--- a/Manual_Tests/US09_MANUAL_TESTS.md
+++ b/Manual_Tests/US09_MANUAL_TESTS.md
@@ -1,0 +1,146 @@
+# US-09 Manual Test Cases
+
+## Preconditions
+- Backend server is running.
+- Frontend app is running and user is logged in.
+- At least one active trip exists with destinations.
+- A second registered user is available for permission tests.
+
+## TC1 - Delete Button Visibility (Creator, No Activities)
+1. Log in as User A who created a trip.
+2. Add a destination (e.g., "Paris") to the trip.
+3. View the trip room.
+
+Expected:
+- The destination card displays Edit and Delete buttons under the score.
+- Both buttons are visible and clickable.
+- No console errors appear.
+
+## TC2 - Delete Button Hidden for Non-Creator
+1. Log in as User A and create a trip.
+2. Add a destination (e.g., "Berlin").
+3. Log out and log in as User B.
+4. Join the trip with an invite code.
+5. View the trip room.
+
+Expected:
+- User B's view does NOT show Edit or Delete buttons for the "Berlin" destination.
+- The destination card still displays the score and name.
+
+## TC3 - Delete Button Hidden When Activities Exist
+1. Log in as User A who created a trip with a destination "London".
+2. Add an activity to the "London" destination (e.g., "Visit Big Ben").
+3. View the trip room.
+
+Expected:
+- The Delete button is NOT visible for "London".
+- Only the destination name and score are displayed.
+- Edit button is also hidden due to activity presence.
+
+## TC4 - Confirmation Dialog Appears on Delete Click
+1. Log in as User A who created a trip.
+2. Add a destination (e.g., "Amsterdam") with no activities.
+3. Click the Delete button.
+
+Expected:
+- A confirmation dialog appears with text like "Are you sure you want to delete 'Amsterdam'?"
+- Dialog shows "Yes, delete" and "Cancel" buttons.
+- The page behind the dialog is slightly dimmed or blurred.
+
+## TC5 - Successful Deletion After Confirmation
+1. Follow TC4 to open the confirmation dialog.
+2. Click "Yes, delete".
+
+Expected:
+- The confirmation dialog closes.
+- The "Amsterdam" destination disappears from the destination list.
+- No error message is shown.
+- The trip room updates in real-time (if multiple users are connected, they also see the destination removed).
+
+## TC6 - Deletion Cancelled
+1. Follow TC4 to open the confirmation dialog.
+2. Click "Cancel".
+
+Expected:
+- The confirmation dialog closes.
+- The "Amsterdam" destination remains in the list.
+- No deletion occurs.
+
+## TC7 - Error Message: Cannot Delete (Has Activities)
+1. Log in as User A who created a destination "Rome" with an activity.
+2. Try to directly trigger a delete request (or simulate attempting to delete via DevTools).
+
+Expected:
+- An error message appears: "This destination has activities. Please remove them first before deleting."
+- The destination remains in the list.
+- No deletion occurs.
+
+## TC8 - Error Message: Not Creator
+1. Log in as User A and create a trip with destination "Venice".
+2. Log out and log in as User B.
+3. Join the trip.
+4. Attempt to delete "Venice" (e.g., via DevTools simulating a DELETE request with User B's token).
+
+Expected:
+- An error message appears: "You can only delete destinations you created."
+- The destination remains in the list.
+- No deletion occurs.
+
+## TC9 - Real-Time Update on Deletion
+1. Open the trip room in two browser windows/tabs:
+   - Tab A: Logged in as User A (creator).
+   - Tab B: Logged in as User B (participant).
+2. In Tab A, add a destination "Tokyo" with no activities.
+3. Ensure both tabs show "Tokyo" in the destination list.
+4. In Tab A, delete "Tokyo" and confirm.
+
+Expected:
+- "Tokyo" disappears from Tab A's list immediately.
+- "Tokyo" disappears from Tab B's list within 1-2 seconds (SSE real-time update).
+- No errors in either tab's console.
+
+## TC10 - Edit and Delete Buttons Together
+1. Log in as User A who created a trip.
+2. Add a destination (e.g., "Barcelona").
+3. View the destination card.
+
+Expected:
+- Both Edit and Delete buttons appear under the score.
+- Edit button allows inline editing of the destination name.
+- Delete button triggers the confirmation dialog.
+- After editing and saving, the destination name updates and buttons remain visible.
+
+## TC11 - Read-Only Mode Hides Delete Button
+1. Log in as User A and create a trip.
+2. Add a destination "Madrid".
+3. Finalize or close the trip (enter read-only mode).
+4. View the trip room.
+
+Expected:
+- The Delete button is NOT visible.
+- No delete action can be triggered.
+- An appropriate read-only indicator is displayed (if applicable).
+
+## TC12 - Multiple Deletions in Sequence
+1. Log in as User A who created a trip.
+2. Add three destinations: "Paris", "London", "Rome".
+3. Delete "Paris" and confirm.
+4. Delete "London" and confirm.
+5. View the destination list.
+
+Expected:
+- "Paris" and "London" are removed.
+- "Rome" remains.
+- No errors occur.
+- The trip room remains responsive.
+
+## TC13 - Destination Not Found Error
+1. Log in as User A who created a trip.
+2. Add a destination "Berlin".
+3. Open the trip in another window and delete "Berlin" from there.
+4. In the original window, attempt to delete "Berlin" (or refresh and try).
+
+Expected:
+- An error message appears: "Destination not found. It may have already been deleted."
+- The destination list updates to remove "Berlin".
+- No exception is logged in the backend.

--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -225,4 +225,16 @@ export class ApiService {
       { content },
     );
   }
+
+  /**
+   * Delete a destination.
+   * @param tripId - The trip ID.
+   * @param destinationId - The destination ID to delete.
+   */
+  public async deleteDestination(
+    tripId: number | string,
+    destinationId: number,
+  ): Promise<void> {
+    return this.delete(`/trips/${tripId}/destinations/${destinationId}`);
+  }
 }

--- a/app/trips/[id]/page.tsx
+++ b/app/trips/[id]/page.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useRouter, useParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { ActivitySearchResult } from "@/types/activity";
@@ -128,6 +128,7 @@ export default function TripRoom() {
   const [activityModalDestinationId, setActivityModalDestinationId] = useState<number | null>(null);
   const [editingDestinationId, setEditingDestinationId] = useState<number | null>(null);
   const [editingDestinationName, setEditingDestinationName] = useState("");
+  const editingDestinationInputRef = useRef<HTMLInputElement | null>(null);
   const [activityQuery, setActivityQuery] = useState("");
   const [activityLocation, setActivityLocation] = useState("");
   const [activityLocationCoords, setActivityLocationCoords] = useState("");
@@ -141,6 +142,8 @@ export default function TripRoom() {
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [activityToDelete, setActivityToDelete] = useState<{ activity: ActivitySearchResult; destinationId: number } | null>(null);
+  const [deleteDestinationConfirmOpen, setDeleteDestinationConfirmOpen] = useState(false);
+  const [destinationToDelete, setDestinationToDelete] = useState<Destination | null>(null);
   const [commentsByActivity, setCommentsByActivity] = useState<Record<number, Comment[]>>({});
   const [selectedActivityForComment, setSelectedActivityForComment] = useState<number | null>(null);
   const [commentInput, setCommentInput] = useState("");
@@ -179,6 +182,52 @@ export default function TripRoom() {
       closeDeleteConfirm();
     }
   }, [activityToDelete, apiService, closeDeleteConfirm, trip]);
+
+  const handleDeleteDestination = useCallback(async () => {
+    if (!tripId || !destinationToDelete || !token) return;
+
+    try {
+      setDestinationLoading(true);
+      await apiService.deleteDestination(Number(tripId), destinationToDelete.id);
+
+      // Remove destination from UI
+      setDestinations((prev) => prev.filter((d) => d.id !== destinationToDelete.id));
+
+      // Clear selected if it was the deleted destination
+      if (selectedDestinationId === destinationToDelete.id) {
+        setSelectedDestinationId(null);
+      }
+
+      // Show success feedback
+      setFeedback({
+        type: "success",
+        text: `Destination "${destinationToDelete.destinationName}" deleted successfully.`,
+      });
+
+      // Close dialog
+      setDeleteDestinationConfirmOpen(false);
+      setDestinationToDelete(null);
+    } catch (err: unknown) {
+      const errorMessage = (err as { message?: string })?.message || "Failed to delete destination";
+      const status = (err as { status?: number })?.status;
+
+      let userMessage = errorMessage;
+      if (status === 403) {
+        userMessage = "You can only delete destinations you created.";
+      } else if (status === 409) {
+        userMessage = "This destination has activities. Please remove them first before deleting.";
+      } else if (status === 404) {
+        userMessage = "Destination not found. It may have already been deleted.";
+      }
+
+      setFeedback({
+        type: "error",
+        text: userMessage,
+      });
+    } finally {
+      setDestinationLoading(false);
+    }
+  }, [tripId, destinationToDelete, token, apiService, selectedDestinationId]);
 
   const isHost = useMemo(() => {
     if (!trip) return false;
@@ -373,7 +422,9 @@ export default function TripRoom() {
       } catch (error) {
         const err = error as Error & { status?: number };
         console.error("Failed to load final report:", err);
-        if (err.status !== 404) {
+        if (err.status === 404) {
+          setReportError("Final report is not available yet.");
+        } else {
           setReportError(err.message || "Failed to load final report.");
         }
       } finally {
@@ -495,15 +546,16 @@ export default function TripRoom() {
     setEditingDestinationName("");
   }, []);
 
-  const saveEditedDestination = useCallback(async (destinationId: number) => {
+  const saveEditedDestination = useCallback(async (destinationId: number, rawName?: string) => {
     if (!trip?.id) return;
-    if (!editingDestinationName.trim()) {
+    const nextName = (rawName ?? editingDestinationInputRef.current?.value ?? editingDestinationName).trim();
+    if (!nextName) {
       setFeedback({ type: "error", text: "Destination name cannot be empty." });
       return;
     }
 
     try {
-      const updated = await apiService.put<unknown>(`/trips/${trip.id}/destinations/${destinationId}`, { name: editingDestinationName.trim() });
+      const updated = await apiService.put<unknown>(`/trips/${trip.id}/destinations/${destinationId}`, { destinationName: nextName });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const u = updated as any;
       const normalized = {
@@ -1178,27 +1230,7 @@ export default function TripRoom() {
                     {destination.destinationName}
                   </button>
 
-                  {editingDestinationId === destination.id ? (
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        value={editingDestinationName}
-                        onChange={(e) => setEditingDestinationName(e.target.value)}
-                        className="rounded-md border border-gray-300 px-2 py-1 text-sm outline-none"
-                      />
-                      <button onClick={() => void saveEditedDestination(destination.id)} className="rounded-md bg-green-500 px-3 py-1 text-xs text-white">Save</button>
-                      <button onClick={cancelEditDestination} className="rounded-md border border-gray-300 px-3 py-1 text-xs">Cancel</button>
-                    </div>
-                  ) : Number(currentUserId) === destination.proposedByUserId && (destination.activities?.length ?? 0) === 0 ? (
-                    <button
-                      type="button"
-                      onClick={() => startEditDestination(destination.id, destination.destinationName ?? "")}
-                      className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-50"
-                      title="Edit destination"
-                    >
-                      Edit
-                    </button>
-                  ) : null}
+                  {/* selection button only - edit/delete moved into cards */}
                 </div>
               ))}
             </div>
@@ -1321,9 +1353,42 @@ export default function TripRoom() {
                       </div>
                     )}
                     <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <h2 className="truncate text-3xl font-bold text-gray-900" title={destination.destinationName ?? undefined}>{destination.destinationName}</h2>
-                        <p className="mt-1 text-xs text-gray-500">Live score from activity votes</p>
+                      <div className="min-w-0 flex-1">
+                        {editingDestinationId === destination.id ? (
+                          <>
+                            <input
+                              type="text"
+                              value={editingDestinationName}
+                              ref={editingDestinationInputRef}
+                              onChange={(event) => setEditingDestinationName(event.target.value)}
+                              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-3xl font-bold text-gray-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100"
+                              aria-label="Destination name"
+                              autoFocus
+                            />
+                            <p className="mt-1 text-xs text-gray-500">Live score from activity votes</p>
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              <button
+                                type="button"
+                                onClick={() => void saveEditedDestination(destination.id, editingDestinationInputRef.current?.value)}
+                                className="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700 hover:bg-blue-100"
+                              >
+                                Save
+                              </button>
+                              <button
+                                type="button"
+                                onClick={cancelEditDestination}
+                                className="rounded-md border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <h2 className="truncate text-3xl font-bold text-gray-900" title={destination.destinationName ?? undefined}>{destination.destinationName}</h2>
+                            <p className="mt-1 text-xs text-gray-500">Live score from activity votes</p>
+                          </>
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         {isWinner && (
@@ -1336,6 +1401,42 @@ export default function TripRoom() {
                         </span>
                       </div>
                     </div>
+
+                    {/* Action buttons under the score */}
+                    {editingDestinationId !== destination.id && (
+                      <div className="mt-4 flex gap-2">
+                        {(() => {
+                          const canModify =
+                            currentUserId !== undefined &&
+                            Number(currentUserId) === Number(destination.proposedByUserId) &&
+                            (destination.activities?.length ?? 0) === 0 &&
+                            !isReadOnlyMode;
+                          return canModify;
+                        })() && (
+                          <>
+                          <button
+                            type="button"
+                            onClick={() => startEditDestination(destination.id, destination.destinationName ?? "")}
+                            className="rounded-md border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                            title="Edit destination"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDestinationToDelete(destination);
+                              setDeleteDestinationConfirmOpen(true);
+                            }}
+                            className="rounded-md border border-red-200 bg-red-50 px-3 py-1 text-sm font-semibold text-red-700 hover:bg-red-100"
+                            title="Delete destination"
+                          >
+                            Delete
+                          </button>
+                          </>
+                        )}
+                      </div>
+                    )}
 
                     <div className="mt-5 space-y-4">
                       {items.length === 0 ? (
@@ -1768,7 +1869,7 @@ export default function TripRoom() {
                   )}
                 </div>
 
-                <div className="border-t border-gray-200 bg-gray-50 px-6 py-4 flex justify-between">
+                <div className="sticky bottom-0 border-t border-gray-200 bg-gray-50 px-6 py-4 flex justify-between">
                   <button
                     type="button"
                     onClick={handleDownloadReport}
@@ -1813,6 +1914,35 @@ export default function TripRoom() {
                     className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700"
                   >
                     Delete
+                  </button>
+                </div>
+              </DialogPanel>
+            </div>
+          </Dialog>
+
+          <Dialog open={deleteDestinationConfirmOpen} onClose={() => { setDeleteDestinationConfirmOpen(false); setDestinationToDelete(null); }} className="relative z-50">
+            <DialogBackdrop className="fixed inset-0 bg-black/30" />
+            <div className="fixed inset-0 flex items-center justify-center p-4">
+              <DialogPanel className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl ring-1 ring-gray-200">
+                <DialogTitle className="text-lg font-semibold text-gray-900">Delete Destination</DialogTitle>
+                <p className="mt-2 text-sm text-gray-600">
+                  Are you sure you want to delete <span className="font-semibold">{destinationToDelete?.destinationName}</span>? This action cannot be undone.
+                </p>
+                <div className="mt-5 flex justify-end gap-3">
+                  <button
+                    type="button"
+                    onClick={() => { setDeleteDestinationConfirmOpen(false); setDestinationToDelete(null); }}
+                    className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDeleteDestination()}
+                    disabled={destinationLoading}
+                    className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                  >
+                    {destinationLoading ? "Deleting..." : "Delete"}
                   </button>
                 </div>
               </DialogPanel>


### PR DESCRIPTION
-move Edit/Delete controls into each destination card under the score
-show the actions only for the creator, only when there are no activities, and only outside read-only mode
-add inline edit UI with Save/Cancel inside the card
-wire destination update and delete requests through the API service
-handle permission and validation errors in the UI
-Manual tests
 close #111 close #101 close #93 close #106 close #100 close #123
